### PR TITLE
refactor: shared config.ts for EVM examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+dist/
 
 # Tooling
 .DS_Store

--- a/fireblocks/evm/README.md
+++ b/fireblocks/evm/README.md
@@ -24,6 +24,13 @@ yarn install
 3. Copy API user key and private key created with Fireblocks into root directory of this repo.
 Refer to `fireblocks_api_key.example` and `fireblocks_private_key.example` files to verify that
 the format of the key matches values expected by the scripts.
+4. Fill in `fireblocks/evm/config.ts` **once**. The shared network/token/vault
+identifiers (`CHAIN_ID`, `FACTORY_ADDRESS`, `ISSUER_ADDRESS`, `TOKEN_ADDRESS`,
+`TOKEN_DECIMALS`, `VAULT_ID`, `ASSET_ID`) and the Fireblocks client live here and
+every script reads them, so you don't repeat them per file. Set `TOKEN_ADDRESS`
+after you deploy a token — `deployToken.ts` prints it. Operation-specific knobs
+(token properties, recipients, amounts, the per-transaction note and
+externalTxId) stay in the individual scripts.
 
 ## Token lifecycle actions
 Two set of examples are given:
@@ -32,8 +39,8 @@ Two set of examples are given:
 
 ### Deploying new token
 
-1. Customize configuration in `fireblocks/evm/deployToken.ts`.
-1. Customize `fireblocks/evm/deployToken.ts` to select the vault and chain that will be used for the deployment.
+1. Select the vault and chain in `fireblocks/evm/config.ts` (`VAULT_ID`,
+   `ASSET_ID`, `CHAIN_ID`), then customize the token in `fireblocks/evm/deployToken.ts`.
 1. To deploy the token run:
 ```
 yarn tsx ./fireblocks/evm/deployToken.ts

--- a/fireblocks/evm/burnTokens.ts
+++ b/fireblocks/evm/burnTokens.ts
@@ -1,22 +1,19 @@
-import { BasePath, Fireblocks, TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
+import { TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
 import { ethers } from "ethers";
-import fs from "fs";
+import {
+  ASSET_ID,
+  fireblocksClient,
+  TOKEN_ADDRESS,
+  TOKEN_DECIMALS,
+  VAULT_ID,
+} from "./config";
 
-// Edit the values below according to your needs
-// The address of the token contract to burn tokens from
-const CONTRACT_ADDRESS = "0x...";
+// The token contract, decimals, vault, and client come from ./config. The knob
+// below is specific to burning.
 // The amount of tokens to be burned
 const AMOUNT_TO_BURN = "3.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 
 const fireblocksParams = {
-  // Vault ID that is used to sign the transaction,
-  // Could be any vault with enough balance to cover the transaction fee that owns the tokens
-  vaultId: "0",
-  // Determines the network where transaction is executed,
-  // refer to Fireblocks documentation for other native asset codes
-  assetId: "ETH_TEST5",
   // Unique ID to ensure that the transaction is not run twice
   // https://developers.fireblocks.com/docs/creating-a-transaction#api-idempotency-best-practice
   externalTxId: "012345",
@@ -30,11 +27,7 @@ const BURN_ABI = [
   "function burn(uint256 amount) external",
 ];
 
-const fireblocks = new Fireblocks({
-  apiKey: fs.readFileSync("./fireblocks/evm/fireblocks_api_key", "utf-8").trim(),
-  basePath: BasePath.EU,
-  secretKey: fs.readFileSync("./fireblocks/evm/fireblocks_private_key", "utf-8").trim()
-});
+const fireblocks = fireblocksClient();
 
 (async() => {
   // Initialize contract interface
@@ -51,15 +44,15 @@ const fireblocks = new Fireblocks({
   const tx = await fireblocks.transactions.createTransaction({
     transactionRequest: {
       operation: TransactionOperation.ContractCall,
-      assetId: fireblocksParams.assetId,
+      assetId: ASSET_ID,
       source: {
         type: TransferPeerPathType.VaultAccount,
-        id: fireblocksParams.vaultId,
+        id: VAULT_ID,
       },
       destination: {
         type: TransferPeerPathType.OneTimeAddress,
         oneTimeAddress: {
-          address: CONTRACT_ADDRESS,
+          address: TOKEN_ADDRESS,
         },
       },
       note: fireblocksParams.note,

--- a/fireblocks/evm/config.ts
+++ b/fireblocks/evm/config.ts
@@ -1,0 +1,45 @@
+import { BasePath, Fireblocks } from "@fireblocks/ts-sdk";
+import fs from "fs";
+
+// ============================================================================
+// Shared configuration for the Fireblocks EVM examples. Edit these once; every
+// script reads the network/token/vault identifiers from here so you don't
+// repeat them across files when running the full lifecycle. Operation-specific
+// knobs (token properties, recipients, amounts, the per-transaction note and
+// externalTxId) stay in the individual scripts.
+// ============================================================================
+
+// Chain ID of the target EVM network (11155111 = Ethereum Sepolia testnet).
+// Supported networks are listed in the Bitbond Token Tool documentation.
+export const CHAIN_ID = 11155111;
+
+// Token Tool factory contract for CHAIN_ID (from the Token Tool documentation).
+export const FACTORY_ADDRESS = "0x4904Ba3148147D2f78b05a8446C01c48a7ABa4bd";
+
+// The Fireblocks vault account address that deploys and owns the token.
+export const ISSUER_ADDRESS = "0x...";
+
+// The deployed token contract. Fill this in after running deployToken.ts. Used
+// by mint/burn/transfer.
+export const TOKEN_ADDRESS = "0x...";
+
+// Decimals the token uses. Set at deploy, then reused to parse mint/burn/transfer
+// amounts.
+export const TOKEN_DECIMALS = 18;
+
+// Fireblocks vault ID that signs the transactions. Any vault with enough balance
+// to cover the fee (and that owns the tokens, for mint/burn/transfer).
+export const VAULT_ID = "0";
+
+// Fireblocks native asset code selecting the network (ETH_TEST5 = Sepolia).
+// Refer to the Fireblocks documentation for other native asset codes.
+export const ASSET_ID = "ETH_TEST5";
+
+// Fireblocks client built from the API user key + secret key files. The *_key
+// suffix is gitignored - never commit real keys.
+export const fireblocksClient = (): Fireblocks =>
+  new Fireblocks({
+    apiKey: fs.readFileSync("./fireblocks/evm/fireblocks_api_key", "utf-8").trim(),
+    basePath: BasePath.EU,
+    secretKey: fs.readFileSync("./fireblocks/evm/fireblocks_private_key", "utf-8").trim(),
+  });

--- a/fireblocks/evm/deployToken.ts
+++ b/fireblocks/evm/deployToken.ts
@@ -1,22 +1,20 @@
-import { BasePath, Fireblocks, TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
+import { TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
 import { ethers } from "ethers";
-import fs from "fs";
 import { EVMTokenData } from "../../common/types";
 import { prepareDeployTransaction } from "../../common/evmApi";
+import {
+  ASSET_ID,
+  CHAIN_ID,
+  FACTORY_ADDRESS,
+  fireblocksClient,
+  ISSUER_ADDRESS,
+  TOKEN_DECIMALS,
+  VAULT_ID,
+} from "./config";
 
-// Edit the values below according to your needs
-// Fireblocks vault account address
-const ISSUER_ADDRESS = "0x...";
-// Factory address for the network you are using
-// Address of the factory contract for the network you are using
-// Can be found in the Bitbond Token Tool documentation
-const FACTORY_ADDRESS = "0x4904Ba3148147D2f78b05a8446C01c48a7ABa4bd";
-// Chain ID for Ethereum Sepolia Testnet
-// Should be updated to the correct chain ID for the network you are using
-// Supported networks can be found in the Bitbond Token Tool documentation
-const CHAIN_ID = 11155111;
-
-// Token configuration: Edit values below according to your needs
+// Network/token/vault identifiers (CHAIN_ID, FACTORY_ADDRESS, ISSUER_ADDRESS,
+// TOKEN_DECIMALS, VAULT_ID, ASSET_ID) come from ./config. The token
+// configuration below is specific to deploying an asset.
 const token: EVMTokenData = {
   // The name of the token
   tokenName: "ABC Token",
@@ -25,7 +23,7 @@ const token: EVMTokenData = {
   // The initial supply of tokens to be minted with token creation
   initialSupply: "100",
   // The number of decimals to be used by the token
-  decimals: "18",
+  decimals: TOKEN_DECIMALS.toString(),
   // The owner address of the token contract.
   // Set to issuer address or any other address that will own the contract after creation.
   owner: ISSUER_ADDRESS,
@@ -71,12 +69,6 @@ const token: EVMTokenData = {
 };
 
 const fireblocksParams = {
-  // Vault ID that is used to sign the transaction,
-  // Could be any vault with enough balance to cover the transaction fee that owns the tokens
-  vaultId: "0",
-  // Determines the network where transaction is executed,
-  // refer to Fireblocks documentation for other native asset codes
-  assetId: "ETH_TEST5",
   // Unique ID to ensure that the transaction is not run twice
   // https://developers.fireblocks.com/docs/creating-a-transaction#api-idempotency-best-practice
   externalTxId: "012345",
@@ -91,11 +83,7 @@ const FACTORY_ABI = [
   "function deployContract(bytes calldata bytecode, bytes calldata signature, uint256 _salt, uint40 expiresAt) external returns (address)"
 ];
 
-const fireblocks = new Fireblocks({
-  apiKey: fs.readFileSync("./fireblocks/evm/fireblocks_api_key", "utf-8").trim(),
-  basePath: BasePath.EU,
-  secretKey: fs.readFileSync("./fireblocks/evm/fireblocks_private_key", "utf-8").trim()
-});
+const fireblocks = fireblocksClient();
 
 void (async () => {
   try {
@@ -136,10 +124,10 @@ void (async () => {
     const result = await fireblocks.transactions.createTransaction({
       transactionRequest: {
         operation: TransactionOperation.ContractCall,
-        assetId: fireblocksParams.assetId,
+        assetId: ASSET_ID,
         source: {
           type: TransferPeerPathType.VaultAccount,
-          id: fireblocksParams.vaultId,
+          id: VAULT_ID,
         },
         destination: {
           type: TransferPeerPathType.OneTimeAddress,

--- a/fireblocks/evm/mintTokens.ts
+++ b/fireblocks/evm/mintTokens.ts
@@ -1,24 +1,21 @@
-import { BasePath, Fireblocks, TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
+import { TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
 import { ethers } from "ethers";
-import fs from "fs";
+import {
+  ASSET_ID,
+  fireblocksClient,
+  TOKEN_ADDRESS,
+  TOKEN_DECIMALS,
+  VAULT_ID,
+} from "./config";
 
-// Edit the values below according to your needs
-// The address of the token contract to mint tokens from
-const CONTRACT_ADDRESS = "0x...";
+// The token contract, decimals, vault, and client come from ./config. The knobs
+// below are specific to minting.
 // The address of the recipient to mint tokens to
 const RECIPIENT_ADDRESS = "0x...";
 // The amount of tokens to be minted
 const AMOUNT_TO_MINT = "3.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 
 const fireblocksParams = {
-  // Vault ID that is used to sign the transaction,
-  // Could be any vault with enough balance to cover the transaction fee
-  vaultId: "0",
-  // Determines the network where transaction is executed,
-  // refer to Fireblocks documentation for other native asset codes
-  assetId: "ETH_TEST5",
   // Unique ID to ensure that the transaction is not run twice
   // https://developers.fireblocks.com/docs/creating-a-transaction#api-idempotency-best-practice
   externalTxId: "01234",
@@ -28,11 +25,7 @@ const fireblocksParams = {
   amount: "0",
 };
 
-const fireblocks = new Fireblocks({
-  apiKey: fs.readFileSync("./fireblocks/evm/fireblocks_api_key", "utf-8").trim(),
-  basePath: BasePath.EU,
-  secretKey: fs.readFileSync("./fireblocks/evm/fireblocks_private_key", "utf-8").trim()
-});
+const fireblocks = fireblocksClient();
 
 const MINT_ABI = [
   "function mint(address to, uint256 amount) external",
@@ -53,15 +46,15 @@ const MINT_ABI = [
   const tx = await fireblocks.transactions.createTransaction({
     transactionRequest: {
       operation: TransactionOperation.ContractCall,
-      assetId: fireblocksParams.assetId,
+      assetId: ASSET_ID,
       source: {
         type: TransferPeerPathType.VaultAccount,
-        id: fireblocksParams.vaultId,
+        id: VAULT_ID,
       },
       destination: {
         type: TransferPeerPathType.OneTimeAddress,
         oneTimeAddress: {
-          address: CONTRACT_ADDRESS,
+          address: TOKEN_ADDRESS,
         },
       },
       note: fireblocksParams.note,

--- a/fireblocks/evm/transferTokens.ts
+++ b/fireblocks/evm/transferTokens.ts
@@ -1,24 +1,21 @@
-import { BasePath, Fireblocks, TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
+import { TransactionOperation, TransferPeerPathType } from "@fireblocks/ts-sdk";
 import { ethers } from "ethers";
-import fs from "fs";
+import {
+  ASSET_ID,
+  fireblocksClient,
+  TOKEN_ADDRESS,
+  TOKEN_DECIMALS,
+  VAULT_ID,
+} from "./config";
 
-// Edit the values below according to your needs
-// The address of the token contract to transfer tokens from
-const CONTRACT_ADDRESS = "0x...";
+// The token contract, decimals, vault, and client come from ./config. The knobs
+// below are specific to transferring.
 // The address of the recipient to transfer tokens to
 const RECIPIENT_ADDRESS = "0x...";
 // The amount of tokens to be sent
 const AMOUNT_TO_TRANSFER = "1.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 
 const fireblocksParams = {
-  // Vault ID that is used to sign the transaction,
-  // Could be any vault with enough balance to cover the transaction fee and owns the tokens
-  vaultId: "0",
-  // Determines the network where transaction is executed,
-  // refer to Fireblocks documentation for other native asset codes
-  assetId: "ETH_TEST5",
   // Unique ID to ensure that the transaction is not run twice
   // https://developers.fireblocks.com/docs/creating-a-transaction#api-idempotency-best-practice
   externalTxId: "0123456",
@@ -32,11 +29,7 @@ const TRANSFER_ABI = [
   "function transfer(address to, uint256 amount) external returns (bool)",
 ];
 
-const fireblocks = new Fireblocks({
-  apiKey: fs.readFileSync("./fireblocks/evm/fireblocks_api_key", "utf-8").trim(),
-  basePath: BasePath.EU,
-  secretKey: fs.readFileSync("./fireblocks/evm/fireblocks_private_key", "utf-8").trim()
-});
+const fireblocks = fireblocksClient();
 
 
 (async() => {
@@ -54,15 +47,15 @@ const fireblocks = new Fireblocks({
   const tx = await fireblocks.transactions.createTransaction({
     transactionRequest: {
       operation: TransactionOperation.ContractCall,
-      assetId: fireblocksParams.assetId,
+      assetId: ASSET_ID,
       source: {
         type: TransferPeerPathType.VaultAccount,
-        id: fireblocksParams.vaultId,
+        id: VAULT_ID,
       },
       destination: {
         type: TransferPeerPathType.OneTimeAddress,
         oneTimeAddress: {
-          address: CONTRACT_ADDRESS,
+          address: TOKEN_ADDRESS,
         },
       },
       note: fireblocksParams.note,

--- a/local-key/evm/README.md
+++ b/local-key/evm/README.md
@@ -31,6 +31,13 @@ yarn tsx ./local-key/evm/createWallet.ts
 ```
 Please refer to `private_key.example` file to verify that the format of the key
 matches values expected by the scripts.
+4. Fill in `local-key/evm/config.ts` **once**. The shared network/token
+identifiers (`CHAIN_ID`, `RPC_URL`, `FACTORY_ADDRESS`, `ISSUER_ADDRESS`,
+`TOKEN_ADDRESS`, `TOKEN_DECIMALS`, `PRIVATE_KEY_PATH`) live here and every
+script reads them, so you don't repeat them per file. Set `TOKEN_ADDRESS` after
+you deploy a token — `deployToken.ts` prints it. Operation-specific knobs (token
+properties, recipients, mint/burn/transfer amounts) stay in the individual
+scripts.
 
 ## Token lifecycle actions
 
@@ -75,8 +82,8 @@ Verification publishes the token's source code on the block explorer (e.g.
 Etherscan) so it shows up as "verified". You only need to provide the deployed
 token address - the script handles the verification request for you.
 
-1. Set `CONTRACT_ADDRESS` (the deployed token address printed by
-   `deployToken.ts`), `CHAIN_ID` and `contractName` in
+1. Set `TOKEN_ADDRESS` (the deployed token address printed by `deployToken.ts`)
+   and `CHAIN_ID` in `config.ts`, and `contractName` in
    `local-key/evm/verifyToken.ts`. The `contractName` must match the one used
    when the token was deployed (see `deployToken.ts`).
 1. To verify the token run:

--- a/local-key/evm/burnTokens.ts
+++ b/local-key/evm/burnTokens.ts
@@ -1,30 +1,31 @@
 import { ethers } from "ethers";
 import fs from "fs";
+import {
+  PRIVATE_KEY_PATH,
+  RPC_URL,
+  TOKEN_ADDRESS,
+  TOKEN_DECIMALS,
+} from "./config";
 
-// Edit the values below according to your needs
-// The address of the token contract to burn tokens from
-const CONTRACT_ADDRESS = "0x...";
+// The token contract, decimals, RPC, and signer key come from ./config. The
+// knob below is specific to burning.
 // The amount of tokens to be burned
 const AMOUNT_TO_BURN = "1.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 
 // Private key of the account that will sign the transaction
 // Should be kept secret and never be committed to version control. Keep it in a secure location.
-const privateKey = fs.readFileSync("./local-key/evm/private_key", "utf-8").trim();
-// The RPC URL of EVM network to use, for example Ethereum Sepolia Testnet
-const rpcUrl = "https://ethereum-sepolia-rpc.publicnode.com";
+const privateKey = fs.readFileSync(PRIVATE_KEY_PATH, "utf-8").trim();
 
 const BURN_ABI = [
   "function burn(uint256 amount) external",
 ];
 
 (async () => {
-  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const provider = new ethers.JsonRpcProvider(RPC_URL);
   const signer = new ethers.Wallet(privateKey, provider);
 
   // Create contract instance
-  const contract = new ethers.Contract(CONTRACT_ADDRESS, BURN_ABI, signer);
+  const contract = new ethers.Contract(TOKEN_ADDRESS, BURN_ABI, signer);
 
   // Parse amount of tokens to send taking into account the decimals
   const parsedAmount = ethers.parseUnits(AMOUNT_TO_BURN, TOKEN_DECIMALS);

--- a/local-key/evm/config.ts
+++ b/local-key/evm/config.ts
@@ -1,0 +1,32 @@
+// ============================================================================
+// Shared configuration for the local-key EVM examples. Edit these once; every
+// script reads the network/token identifiers from here so you don't repeat them
+// across files when running the full lifecycle. Operation-specific knobs (token
+// properties, recipients, mint/burn/transfer amounts) stay in the individual
+// scripts.
+// ============================================================================
+
+// Chain ID of the target EVM network (11155111 = Ethereum Sepolia testnet).
+// Supported networks are listed in the Bitbond Token Tool documentation.
+export const CHAIN_ID = 11155111;
+
+// RPC endpoint for CHAIN_ID. Used to sign, send, and confirm transactions.
+export const RPC_URL = "https://ethereum-sepolia-rpc.publicnode.com";
+
+// Token Tool factory contract for CHAIN_ID (from the Token Tool documentation).
+export const FACTORY_ADDRESS = "0x4904Ba3148147D2f78b05a8446C01c48a7ABa4bd";
+
+// The account that deploys and owns the token. Its private key (see below) signs.
+export const ISSUER_ADDRESS = "0x...";
+
+// The deployed token contract. Fill this in after running deployToken.ts (it
+// prints the address). Used by mint/burn/transfer/verify.
+export const TOKEN_ADDRESS = "0x...";
+
+// Decimals the token uses. Set at deploy, then reused to parse mint/burn/transfer
+// amounts.
+export const TOKEN_DECIMALS = 18;
+
+// Path to the file holding the signer's private key. The *_key suffix is
+// gitignored - never commit real keys.
+export const PRIVATE_KEY_PATH = "./local-key/evm/private_key";

--- a/local-key/evm/deployToken.ts
+++ b/local-key/evm/deployToken.ts
@@ -2,19 +2,18 @@ import { ethers } from "ethers";
 import fs from "fs";
 import { EVMTokenData } from "../../common/types";
 import { prepareDeployTransaction } from "../../common/evmApi";
+import {
+  CHAIN_ID,
+  FACTORY_ADDRESS,
+  ISSUER_ADDRESS,
+  PRIVATE_KEY_PATH,
+  RPC_URL,
+  TOKEN_DECIMALS,
+} from "./config";
 
-// Edit the values below according to your needs
-const ISSUER_ADDRESS = "0x...";
-// Factory address for the network you are using
-// Address of the factory contract for the network you are using
-// Can be found in the Bitbond Token Tool documentation
-const FACTORY_ADDRESS = "0x4904Ba3148147D2f78b05a8446C01c48a7ABa4bd";
-// Chain ID for Ethereum Sepolia Testnet
-// Should be updated to the correct chain ID for the network you are using
-// Supported networks can be found in the Bitbond Token Tool documentation
-const CHAIN_ID = 11155111;
-
-// Token configuration: Edit values below according to your needs
+// Network/token identifiers (CHAIN_ID, FACTORY_ADDRESS, ISSUER_ADDRESS,
+// TOKEN_DECIMALS) come from ./config. The token configuration below is specific
+// to deploying an asset.
 const token: EVMTokenData = {
   // The name of the token
   tokenName: "ABC Token",
@@ -23,7 +22,7 @@ const token: EVMTokenData = {
   // The initial supply of tokens to be minted with token creation
   initialSupply: "100",
   // The number of decimals to be used by the token
-  decimals: "18",
+  decimals: TOKEN_DECIMALS.toString(),
   // The owner address of the token contract.
   // Set to issuer address or any other address that will own the contract after creation.
   owner: ISSUER_ADDRESS,
@@ -70,9 +69,7 @@ const token: EVMTokenData = {
 
 // Private key of the account that will sign the transaction
 // Should be kept secret and never be committed to version control. Keep it in a secure location.
-const privateKey = fs.readFileSync("./local-key/evm/private_key", "utf-8").trim();
-// The RPC URL of EVM network to use, for example Ethereum Sepolia Testnet
-const rpcUrl = "https://ethereum-sepolia-rpc.publicnode.com";
+const privateKey = fs.readFileSync(PRIVATE_KEY_PATH, "utf-8").trim();
 
 // Factory ABI - only the deployContract function we need
 const FACTORY_ABI = [
@@ -115,7 +112,7 @@ void (async () => {
     ]);
 
     // Setup provider and signer
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const provider = new ethers.JsonRpcProvider(RPC_URL);
     const signer = new ethers.Wallet(privateKey, provider);
 
     // Prepare transaction with value (deployment cost)

--- a/local-key/evm/mintTokens.ts
+++ b/local-key/evm/mintTokens.ts
@@ -1,32 +1,33 @@
 import { ethers } from "ethers";
 import fs from "fs";
+import {
+  PRIVATE_KEY_PATH,
+  RPC_URL,
+  TOKEN_ADDRESS,
+  TOKEN_DECIMALS,
+} from "./config";
 
-// Edit the values below according to your needs
-// The address of the token contract to mint tokens from
-const CONTRACT_ADDRESS = "0x...";
+// The token contract, decimals, RPC, and signer key come from ./config. The
+// knobs below are specific to minting.
 // The address of the recipient to mint tokens to
 const RECIPIENT_ADDRESS = "0x...";
 // The amount of tokens to be minted
 const AMOUNT_TO_MINT = "3.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 
 // Private key of the account that will sign the transaction
 // Should be kept secret and never be committed to version control. Keep it in a secure location.
-const privateKey = fs.readFileSync("./local-key/evm/private_key", "utf-8").trim();
-// The RPC URL of EVM network to use, for example Ethereum Sepolia Testnet
-const rpcUrl = "https://ethereum-sepolia-rpc.publicnode.com";
+const privateKey = fs.readFileSync(PRIVATE_KEY_PATH, "utf-8").trim();
 
 const MINT_ABI = [
   "function mint(address to, uint256 amount) external",
 ];
 
 (async () => {
-  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const provider = new ethers.JsonRpcProvider(RPC_URL);
   const signer = new ethers.Wallet(privateKey, provider);
 
   // Create contract instance
-  const contract = new ethers.Contract(CONTRACT_ADDRESS, MINT_ABI, signer);
+  const contract = new ethers.Contract(TOKEN_ADDRESS, MINT_ABI, signer);
 
   // Parse amount of tokens to send taking into account the decimals
   const parsedAmount = ethers.parseUnits(AMOUNT_TO_MINT, TOKEN_DECIMALS);

--- a/local-key/evm/transferTokens.ts
+++ b/local-key/evm/transferTokens.ts
@@ -1,32 +1,33 @@
 import { ethers } from "ethers";
 import fs from "fs";
+import {
+  PRIVATE_KEY_PATH,
+  RPC_URL,
+  TOKEN_ADDRESS,
+  TOKEN_DECIMALS,
+} from "./config";
 
-// Edit the values below according to your needs
-// The address of the token contract to transfer tokens from
-const CONTRACT_ADDRESS = "0x...";
+// The token contract, decimals, RPC, and signer key come from ./config. The
+// knobs below are specific to transferring.
 // The address of the recipient to transfer tokens to
 const RECIPIENT_ADDRESS = "0x...";
 // The amount of tokens to be sent
 const AMOUNT_TO_TRANSFER = "1.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 
 // Private key of the account that will sign the transaction
 // Should be kept secret and never be committed to version control. Keep it in a secure location.
-const privateKey = fs.readFileSync("./local-key/evm/private_key", "utf-8").trim();
-// The RPC URL of EVM network to use, for example Ethereum Sepolia Testnet
-const rpcUrl = "https://ethereum-sepolia-rpc.publicnode.com";
+const privateKey = fs.readFileSync(PRIVATE_KEY_PATH, "utf-8").trim();
 
 const TRANSFER_ABI = [
   "function transfer(address to, uint256 amount) external returns (bool)",
 ];
 
 (async () => {
-  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const provider = new ethers.JsonRpcProvider(RPC_URL);
   const signer = new ethers.Wallet(privateKey, provider);
 
   // Create contract instance
-  const contract = new ethers.Contract(CONTRACT_ADDRESS, TRANSFER_ABI, signer);
+  const contract = new ethers.Contract(TOKEN_ADDRESS, TRANSFER_ABI, signer);
 
   // Parse amount of tokens to send taking into account the decimals
   const parsedAmount = ethers.parseUnits(AMOUNT_TO_TRANSFER, TOKEN_DECIMALS);

--- a/local-key/evm/verifyToken.ts
+++ b/local-key/evm/verifyToken.ts
@@ -5,17 +5,10 @@ import {
   submitVerification,
   pollVerificationStatus,
 } from "../../common/verifyApi";
+import { CHAIN_ID, RPC_URL, TOKEN_ADDRESS } from "./config";
 
-// Edit the values below according to your needs
-
-// Address of the token contract you want to verify.
-// This is the deployed token address, which deployToken.ts prints on success.
-const CONTRACT_ADDRESS = "0x...";
-
-// Chain ID of the network the token was deployed to.
-// Should match the CHAIN_ID used in deployToken.ts (11155111 = Sepolia Testnet).
-// Supported networks can be found in the Bitbond Token Tool documentation.
-const CHAIN_ID = 11155111;
+// The token contract (TOKEN_ADDRESS), CHAIN_ID, and RPC_URL come from ./config.
+// The knobs below are specific to verification.
 
 // Source contract name of the deployed token. The default token deployed by
 // deployToken.ts uses "FullFeatureTokenV2".
@@ -24,10 +17,6 @@ const contractName = "FullFeatureTokenV2";
 // Block explorer to verify the contract on. Use the default explorer for your
 // network ("etherscan" for Ethereum/Sepolia).
 const explorerName: ExplorerName = "etherscan";
-
-// The RPC URL of the EVM network the token lives on, for example Ethereum
-// Sepolia Testnet.
-const rpcUrl = "https://ethereum-sepolia-rpc.publicnode.com";
 
 // Minimal ABI to read the contract name and hash from the deployed token.
 const CONTRACT_METADATA_ABI = [
@@ -41,9 +30,9 @@ const DEFAULT_HASH =
 
 void (async () => {
   try {
-    const provider = new ethers.JsonRpcProvider(rpcUrl);
+    const provider = new ethers.JsonRpcProvider(RPC_URL);
     const contract = new ethers.Contract(
-      CONTRACT_ADDRESS,
+      TOKEN_ADDRESS,
       CONTRACT_METADATA_ABI,
       provider
     );
@@ -59,7 +48,7 @@ void (async () => {
     console.log("Resolving creation transaction...");
     const creationTxHash = await getCreationTransactionHash({
       chainId: CHAIN_ID,
-      address: CONTRACT_ADDRESS,
+      address: TOKEN_ADDRESS,
       explorerName,
     });
 
@@ -67,7 +56,7 @@ void (async () => {
     const guid = await submitVerification({
       contractName,
       chainId: CHAIN_ID,
-      contractAddress: CONTRACT_ADDRESS,
+      contractAddress: TOKEN_ADDRESS,
       customContractName,
       creationTxHash,
       contractHash,

--- a/metaco/evm/README.md
+++ b/metaco/evm/README.md
@@ -27,14 +27,18 @@ Example token deployment: [Block explorer](https://sepolia.etherscan.io/tx/0xd75
 yarn install
 ```
 3. Follow Harmonize setup instructions to create an API user.
+4. Fill in `metaco/evm/config.ts` **once**. The shared network/token identifiers
+   (`CHAIN_ID`, `FACTORY_ADDRESS`, `ISSUER_ADDRESS`, `TOKEN_DECIMALS`) live here
+   and every script reads them, so you don't repeat them per file.
+   Operation-specific knobs (token properties, recipients, amounts) stay in the
+   individual scripts.
 
 ## Token lifecycle actions
 
 ### Deploying new token
 
-1. Customize configuration in `deployToken.ts`:
-   - Set `ISSUER_ADDRESS` to your wallet address
-   - Configure `CHAIN_ID` for your target network (e.g., 11155111 for Sepolia)
+1. Set `ISSUER_ADDRESS` and `CHAIN_ID` (e.g., 11155111 for Sepolia) in
+   `config.ts`, then customize the token in `deployToken.ts`:
    - Update token parameters (name, symbol, supply, etc.)
    - Set token properties (mintable, burnable, pausable, etc.)
 
@@ -59,7 +63,6 @@ yarn tsx metaco/evm/deployToken.ts
 
 1. Customize transfer parameters in `transferTokens.ts`:
    - Set `AMOUNT_TO_TRANSFER` to the amount of tokens to send
-   - Set `TOKEN_DECIMALS` to match your token's decimals
    - Set `RECIPIENT_ADDRESS` to the destination address
 
 2. Generate the transfer calldata:
@@ -76,9 +79,7 @@ yarn tsx metaco/evm/transferTokens.ts
 ### Minting tokens
 
 1. Customize minting parameters in `mintTokens.ts`:
-   - Set `AMOUNT_TO_MINT` to the amount of tokens to mint
-   - Set `TOKEN_DECIMALS` to match your token's decimals
-   - Set `RECIPIENT_ADDRESS` to the address receiving the tokens
+   - Set `AMOUNT_TO_MINT` to the amount of tokens to mint   - Set `RECIPIENT_ADDRESS` to the address receiving the tokens
 
 2. Generate the mint calldata:
 ```bash
@@ -95,8 +96,6 @@ yarn tsx metaco/evm/mintTokens.ts
 
 1. Customize burning parameters in `burnTokens.ts`:
    - Set `AMOUNT_TO_BURN` to the amount of tokens to burn
-   - Set `TOKEN_DECIMALS` to match your token's decimals
-
 2. Generate the burn calldata:
 ```bash
 yarn tsx metaco/evm/burnTokens.ts

--- a/metaco/evm/burnTokens.ts
+++ b/metaco/evm/burnTokens.ts
@@ -1,10 +1,9 @@
 import { ethers } from "ethers";
+import { TOKEN_DECIMALS } from "./config";
 
-// Edit the values below according to your needs
+// TOKEN_DECIMALS comes from ./config. The knob below is specific to burning.
 // The amount of tokens to be burned
 const AMOUNT_TO_BURN = "1.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 
 const BURN_ABI = [
   "function burn(uint256 amount) external",

--- a/metaco/evm/config.ts
+++ b/metaco/evm/config.ts
@@ -1,0 +1,20 @@
+// ============================================================================
+// Shared configuration for the Metaco Harmonize EVM examples. Edit these once;
+// every script reads the network/token identifiers from here so you don't
+// repeat them across files. Operation-specific knobs (token properties,
+// recipients, amounts) stay in the individual scripts.
+// ============================================================================
+
+// Chain ID of the target EVM network (11155111 = Ethereum Sepolia testnet).
+// Supported networks are listed in the Bitbond Token Tool documentation.
+export const CHAIN_ID = 11155111;
+
+// Token Tool factory contract for CHAIN_ID (from the Token Tool documentation).
+export const FACTORY_ADDRESS = "0x4904Ba3148147D2f78b05a8446C01c48a7ABa4bd";
+
+// The account that deploys and owns the token.
+export const ISSUER_ADDRESS = "0x...";
+
+// Decimals the token uses. Set at deploy, then reused to parse mint/burn/transfer
+// amounts.
+export const TOKEN_DECIMALS = 18;

--- a/metaco/evm/deployToken.ts
+++ b/metaco/evm/deployToken.ts
@@ -1,19 +1,16 @@
 import { ethers } from "ethers";
 import { EVMTokenData } from "../../common/types";
 import { prepareDeployTransaction } from "../../common/evmApi";
+import {
+  CHAIN_ID,
+  FACTORY_ADDRESS,
+  ISSUER_ADDRESS,
+  TOKEN_DECIMALS,
+} from "./config";
 
-// Edit the values below according to your needs
-const ISSUER_ADDRESS = "0x...";
-// Factory address for the network you are using
-// Address of the factory contract for the network you are using
-// Can be found in the Bitbond Token Tool documentation
-const FACTORY_ADDRESS = "0x4904Ba3148147D2f78b05a8446C01c48a7ABa4bd";
-// Chain ID for Ethereum Sepolia Testnet
-// Should be updated to the correct chain ID for the network you are using
-// Supported networks can be found in the Bitbond Token Tool documentation
-const CHAIN_ID = 11155111;
-
-// Token configuration: Edit values below according to your needs
+// Network/token identifiers (CHAIN_ID, FACTORY_ADDRESS, ISSUER_ADDRESS,
+// TOKEN_DECIMALS) come from ./config. The token configuration below is specific
+// to deploying an asset.
 const token: EVMTokenData = {
   // The name of the token
   tokenName: "ABC Token",
@@ -22,7 +19,7 @@ const token: EVMTokenData = {
   // The initial supply of tokens to be minted with token creation
   initialSupply: "100",
   // The number of decimals to be used by the token
-  decimals: "18",
+  decimals: TOKEN_DECIMALS.toString(),
   // The owner address of the token contract.
   // Set to issuer address or any other address that will own the contract after creation.
   owner: ISSUER_ADDRESS,

--- a/metaco/evm/mintTokens.ts
+++ b/metaco/evm/mintTokens.ts
@@ -1,10 +1,9 @@
 import { ethers } from "ethers";
+import { TOKEN_DECIMALS } from "./config";
 
-// Edit the values below according to your needs
+// TOKEN_DECIMALS comes from ./config. The knobs below are specific to minting.
 // The amount of tokens to be minted
 const AMOUNT_TO_MINT = "3.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 // The address the tokens will be transferred to during minting
 const RECIPIENT_ADDRESS = "0x...";
 

--- a/metaco/evm/transferTokens.ts
+++ b/metaco/evm/transferTokens.ts
@@ -1,10 +1,9 @@
 import { ethers } from "ethers";
+import { TOKEN_DECIMALS } from "./config";
 
-// Edit the values below according to your needs
+// TOKEN_DECIMALS comes from ./config. The knobs below are specific to transferring.
 // The amount of tokens to be sent
 const AMOUNT_TO_TRANSFER = "1.0";
-// The number of decimals the token uses
-const TOKEN_DECIMALS = 18;
 // The address the tokens will be transferred to
 const RECIPIENT_ADDRESS = "0x...";
 


### PR DESCRIPTION
Extract the repeated network/token identifiers in the local-key/evm, fireblocks/evm, and metaco/evm examples into a per-group config.ts, so they are edited once instead of per script. Operation-specific knobs stay in the individual scripts. Also gitignore the tsc build output (dist/).